### PR TITLE
For future development:

### DIFF
--- a/models/game.js
+++ b/models/game.js
@@ -11,8 +11,8 @@ Game.init(
         id: {
 
             type: DataTypes.INTEGER,
-            autoincrement: true,
-            defaultValue: 1000,
+            autoIncrement: true,
+            // defaultValue: 1000,
             allowNull: false,
             primaryKey: true
         },


### PR DESCRIPTION
changed autoincrement to autoIncrement so when we add a feature to add new games they'll have auto ID
+ avoid an "Invalid default value for 'id'" error once the autoIncrement is fixed